### PR TITLE
Add support for a custom Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,18 @@ const premium = new Grammarly({
 ```
 
 Your own personal AuthTokens can be found by inspecting the Firefox extension and looking at the `Cookies` tab.
+
+
+#### Using a custom http Agent
+
+If you need to support your own proxy, you can define your own [agent (doc)](https://nodejs.org/api/http.html#http_new_agent_options) for the requests.
+ex:
+```js
+import ProxyAgent from 'proxy-agent';
+
+new Grammarly({
+  agent: new ProxyAgent(process.env.http_proxy)
+});
+```
+
+It's going to use it for all the requests made by the lib (websockets + fetch);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,6 +23,7 @@ export interface GrammarlyOptions {
   password?: string;
 
   auth?: RequiredAuth;
+  agent?: any
 }
 
 /**
@@ -107,7 +108,7 @@ export class Grammarly {
   private async establish(): Promise<BaseMessage> {
     consola.debug('Re-establishing connection.');
 
-    const { connection } = await connect(this.options.auth);
+    const { connection } = await connect(this.options.auth, this.options.agent);
 
     this.connection = connection;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -37,6 +37,13 @@ export interface AuthHostOrigin {
   Origin: string;
 }
 
+export interface AuthRequestSettings {
+  origin?: string;
+  host?: string;
+  authUrl?: string;
+  agent?: any;
+}
+
 //
 // Functions
 //
@@ -172,11 +179,12 @@ export function parseResponseCookies(cookies: string[]): RequiredAuth {
  * objects are used in both initial Cookie transfer and are occasionally sent
  * over the websocket connection.
  */
-export async function buildAuth(
-  origin?: string,
-  host?: string,
-  authUrl?: string
-): Promise<Auth> {
+export async function buildAuth({
+  origin,
+  host,
+  authUrl,
+  agent,
+}: AuthRequestSettings): Promise<Auth> {
   const gnar_containerId = generateContainerId();
   const redirect_location = generateRedirectLocation();
 
@@ -191,7 +199,8 @@ export async function buildAuth(
       gnar_containerId,
       origin,
       host
-    )
+    ),
+    agent
   });
 
   if (!response.ok) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -185,7 +185,7 @@ export async function buildAuth({
   host,
   authUrl,
   agent,
-}: AuthRequestSettings): Promise<Auth> {
+}: AuthRequestSettings = {}): Promise<Auth> {
   const gnar_containerId = generateContainerId();
   const redirect_location = generateRedirectLocation();
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import WebSocket from 'ws'
 import fetch from 'node-fetch';
 import { buildCookieString, CookieOptions } from './connection';
 import env from './env';
@@ -41,7 +42,7 @@ export interface AuthRequestSettings {
   origin?: string;
   host?: string;
   authUrl?: string;
-  agent?: any;
+  agent?: WebSocket.ClientOptions['agent'];
 }
 
 //

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -65,7 +65,7 @@ export function buildWebsocketHeaders(Cookie: string): Headers {
 /**
  * Create the options needed for connecting to the remote Grammarly host.
  */
-export function buildWSOptions(auth: Auth, agent: any): WebSocket.ClientOptions {
+export function buildWSOptions(auth: Auth, agent?: WebSocket.ClientOptions['agent']): WebSocket.ClientOptions {
   const cookie = buildCookieString(getAuthCookies(auth));
 
   return {
@@ -80,7 +80,7 @@ export function buildWSOptions(auth: Auth, agent: any): WebSocket.ClientOptions 
  *
  * @param userAuth a custom user auth object
  */
-export function connect(userAuth?: RequiredAuth, agent?: any): Promise<Connection> {
+export function connect(userAuth?: RequiredAuth, agent?: WebSocket.ClientOptions['agent']): Promise<Connection> {
   return new Promise<Connection>(async (resolve, reject) => {
     const auth = userAuth
       ? buildAuthWithUserTokens(userAuth)

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -64,12 +64,13 @@ export function buildWebsocketHeaders(Cookie: string): Headers {
 /**
  * Create the options needed for connecting to the remote Grammarly host.
  */
-export function buildWSOptions(auth: Auth): WebSocket.ClientOptions {
+export function buildWSOptions(auth: Auth, agent: any): WebSocket.ClientOptions {
   const cookie = buildCookieString(getAuthCookies(auth));
 
   return {
     headers: buildWebsocketHeaders(cookie),
-    origin: env.origin.firefox
+    origin: env.origin.firefox,
+    agent
   };
 }
 
@@ -78,13 +79,13 @@ export function buildWSOptions(auth: Auth): WebSocket.ClientOptions {
  *
  * @param userAuth a custom user auth object
  */
-export function connect(userAuth?: RequiredAuth): Promise<Connection> {
+export function connect(userAuth?: RequiredAuth, agent?: any): Promise<Connection> {
   return new Promise<Connection>(async (resolve, reject) => {
     const auth = userAuth
       ? buildAuthWithUserTokens(userAuth)
       : await buildAuth();
 
-    const server = new WebSocket(env.endpoint, buildWSOptions(auth));
+    const server = new WebSocket(env.endpoint, buildWSOptions(auth, agent));
 
     server.onopen = () => {
       resolve({

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -1,4 +1,3 @@
-import consola from 'consola';
 import WebSocket from 'ws';
 import {
   Auth,
@@ -87,7 +86,6 @@ export function connect(userAuth?: RequiredAuth, agent?: WebSocket.ClientOptions
       : await buildAuth({ agent });
 
     const options = buildWSOptions(auth, agent);
-    consola.debug(options);
     const server = new WebSocket(env.endpoint, options);
 
     server.onopen = () => {

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -1,3 +1,4 @@
+import consola from 'consola';
 import WebSocket from 'ws';
 import {
   Auth,
@@ -83,9 +84,11 @@ export function connect(userAuth?: RequiredAuth, agent?: any): Promise<Connectio
   return new Promise<Connection>(async (resolve, reject) => {
     const auth = userAuth
       ? buildAuthWithUserTokens(userAuth)
-      : await buildAuth();
+      : await buildAuth({ agent });
 
-    const server = new WebSocket(env.endpoint, buildWSOptions(auth, agent));
+    const options = buildWSOptions(auth, agent);
+    consola.debug(options);
+    const server = new WebSocket(env.endpoint, options);
 
     server.onopen = () => {
       resolve({

--- a/src/lib/plagiarism.ts
+++ b/src/lib/plagiarism.ts
@@ -1,3 +1,4 @@
+import WebSocket from 'ws'
 import fetch from 'node-fetch';
 import {
   AuthHostOrigin,
@@ -32,7 +33,7 @@ export function getPlagiarismHostOrigin(): AuthHostOrigin {
  *
  * @author Stewart McGown
  */
-export async function plagiarism(text: string, agent?: any): Promise<PlagiarismResult> {
+export async function plagiarism(text: string, agent?: WebSocket.ClientOptions['agent']): Promise<PlagiarismResult> {
   const { Host, Origin } = getPlagiarismHostOrigin();
 
   const auth = await buildAuth({

--- a/src/lib/plagiarism.ts
+++ b/src/lib/plagiarism.ts
@@ -32,14 +32,15 @@ export function getPlagiarismHostOrigin(): AuthHostOrigin {
  *
  * @author Stewart McGown
  */
-export async function plagiarism(text: string): Promise<PlagiarismResult> {
+export async function plagiarism(text: string, agent?: any): Promise<PlagiarismResult> {
   const { Host, Origin } = getPlagiarismHostOrigin();
 
-  const auth = await buildAuth(
-    Origin,
-    'www.grammarly.com',
-    'https://www.grammarly.com/plagiarism-checker'
-  );
+  const auth = await buildAuth({
+    origin: Origin,
+    host: 'www.grammarly.com',
+    authUrl: 'https://www.grammarly.com/plagiarism-checker',
+    agent
+  });
 
   const results: PartialProblemResponse[] = await fetch(
     'https://capi.grammarly.com/api/check',
@@ -51,7 +52,8 @@ export async function plagiarism(text: string): Promise<PlagiarismResult> {
         Origin,
         Host
       ),
-      body: text
+      body: text,
+      agent
     }
   ).then(r => r.json());
 

--- a/tests/analysis.spec.ts
+++ b/tests/analysis.spec.ts
@@ -8,11 +8,11 @@ describe('further analysis of results', () => {
   Must giev us pause - their's the respect
   That makes clamity of so long life.`;
 
+    const { corrected } = await new Grammarly().analyse(text).then(correct);
+
     const correctText = `When we have shuffled off this mortal coil,
   Must give us pause - their's the respect
   That makes calamity of so long life.`;
-
-    const { corrected } = await new Grammarly().analyse(text).then(correct);
 
     expect(corrected).toEqual(correctText);
   });

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -12,8 +12,9 @@ describe('api tests', () => {
     const server = new Grammarly();
 
     const response = await server.analyse('hello worlds!');
-
-    expect(response.alerts.length).toBe(1);
+    // a hidden alert as we start with hello instead of Hello
+    // We should use a comma after hello
+    expect(response.alerts.length).toBe(2);
 
     done();
   });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature, we add support for a custom Agent when we create requests via ws or fetch. cf https://nodejs.org/api/http.html#http_new_agent_options


* **What is the current behavior?**

If you have a proxy set ex: inside a CI, Node.JS will  break cf https://github.com/nodejs/node/issues/15620 so you need to be able to use a custom agent.


* **What is the new behavior (if this is a feature change)?**

It works :) 

* **Other information**:
