### PR TITLE
Dialect customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This library uses a Promise-based return system, so you will receive all the cor
 }
 ```
 
+There are two more optional arguments for `analyze`: `timeout` and `dialect`.
+* `timeout` is the number of milliseconds to wait before timing out. Defaults to 5000.
+* `dialect` is the dialect of English to use: `'american'` or `'british'`. Defaults to `'british'`.
+
 ### Correct results
 
 ```js

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -117,6 +117,7 @@ export class Grammarly {
     this.connection = connection;
 
     this.connection.send(JSON.stringify(buildInitialMessage(dialect)));
+    this.dialect = dialect
 
     consola.debug('Sent establishing message');
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,6 +31,7 @@ export interface GrammarlyOptions {
  */
 export class Grammarly {
   private connection!: WebSocket;
+  private dialect: 'british';
 
   private get isEstablished(): boolean {
     return (
@@ -47,13 +48,15 @@ export class Grammarly {
    *
    * @param text text to analyse
    * @param timeout how long to wait before we stop collecting results
+   * @param dialect dialect to use
    */
   public async analyse(
     text: string,
-    timeout: number = 30000
+    timeout: number = 30000,
+    dialect: 'american' | 'british' = 'british'
   ): Promise<GrammarlyResult> {
-    if (!this.isEstablished) {
-      await this.establish();
+    if (!this.isEstablished || dialect !== this.dialect) {
+      await this.establish(dialect);
     }
 
     consola.debug('Successfully connected to Grammarly!');
@@ -102,17 +105,18 @@ export class Grammarly {
   /**
    * Establish communication with the Grammarly API.
    *
+   * @param dialect to use
    * @returns the initial response message
    * @throws {Object} if cookies are bad
    */
-  private async establish(): Promise<BaseMessage> {
+  private async establish(dialect: 'american' | 'british' = 'british'): Promise<BaseMessage> {
     consola.debug('Re-establishing connection.');
 
     const { connection } = await connect(this.options.auth, this.options.agent);
 
     this.connection = connection;
 
-    this.connection.send(JSON.stringify(buildInitialMessage()));
+    this.connection.send(JSON.stringify(buildInitialMessage(dialect)));
 
     consola.debug('Sent establishing message');
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,7 +31,7 @@ export interface GrammarlyOptions {
  */
 export class Grammarly {
   private connection!: WebSocket;
-  private dialect: 'british';
+  private dialect: 'american' | 'british';
 
   private get isEstablished(): boolean {
     return (

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -114,7 +114,7 @@ export const stringToTransform = (str: string, pos?: string) => {
   return `+0:${pos || '0'}:${str}:0`;
 };
 
-export const buildInitialMessage = (): InfoMessage => ({
+export const buildInitialMessage = (dialect?: 'american' | 'british' = 'british'): InfoMessage => ({
   type: 'initial',
   docid: uuid.v4(),
   client: 'extension_chrome',
@@ -126,7 +126,7 @@ export const buildInitialMessage = (): InfoMessage => ({
     'sentence_variety_check',
     'free_occasional_premium_alerts'
   ],
-  dialect: 'british',
+  dialect,
   clientVersion: '14.924.2437',
   extDomain: 'keep.google.com',
   action: 'start',

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -114,7 +114,7 @@ export const stringToTransform = (str: string, pos?: string) => {
   return `+0:${pos || '0'}:${str}:0`;
 };
 
-export const buildInitialMessage = (dialect?: 'american' | 'british' = 'british'): InfoMessage => ({
+export const buildInitialMessage = (dialect: 'american' | 'british' = 'british'): InfoMessage => ({
   type: 'initial',
   docid: uuid.v4(),
   client: 'extension_chrome',

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -28,4 +28,14 @@ describe('api tests', () => {
 
     done();
   });
+  
+  it('use a different dialect', async done => {
+    const server = new Grammarly();
+
+    const response = await server.analyse('Hello.', 5000, 'american');
+
+    expect(response.result.dialect).toBe('american');
+    
+    done();
+  });
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature



* **What is the current behavior?** (You can also link to an open issue here)
It always uses British English


* **What is the new behavior (if this is a feature change)?**
An option to use Americain English


* **Other information**:
There is now a 3rd parameter to `analyze`, the dialect to use. It can be `'british'` (the default) or `'american'`.

Resolves #26 